### PR TITLE
Unknown ID Demo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Change Log
 
 ## [0.0.1] - 2020-02-28
-* [#3](https://github.com/Blackjacx/Columbus/pull/3): Another PR - [@blackjacx](https://github.com/blackjacx).
-* [#2](https://github.com/Blackjacx/Columbus/pull/2): Some PR - [@blackjacx](https://github.com/blackjacx).
+* [#3](https://github.com/Blackjacx/ghtest/pull/3): Another PR - [@blackjacx](https://github.com/blackjacx).
+* [#2](https://github.com/Blackjacx/ghtest/pull/2): Some PR - [@blackjacx](https://github.com/blackjacx).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # Change Log
 
 ## [0.0.1] - 2020-02-28
-* [#2](https://github.com/Blackjacx/Columbus/pull/2): Initial Commit - [@blackjacx](https://github.com/blackjacx).
+* [#3](https://github.com/Blackjacx/Columbus/pull/3): Another PR - [@blackjacx](https://github.com/blackjacx).
+* [#2](https://github.com/Blackjacx/Columbus/pull/2): Some PR - [@blackjacx](https://github.com/blackjacx).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Change Log
 
 ## [0.0.1] - 2020-02-28
-* [#3](https://github.com/Blackjacx/ghtest/pull/3): Another PR - [@blackjacx](https://github.com/blackjacx).
+* [#4](https://github.com/Blackjacx/ghtest/pull/4): Another PR - [@blackjacx](https://github.com/blackjacx).
 * [#2](https://github.com/Blackjacx/ghtest/pull/2): Some PR - [@blackjacx](https://github.com/blackjacx).


### PR DESCRIPTION
This PR shows that the action ignores unknown patterns since they do not match any prefix specified in `reference-repo-prefixes`. 

It is important to specify the backlog ticket prefix that should be considered so the action knows which links are actually issue links to post to.

## Issues 
[BAAAACKLOG-2](https://github.com/Blackjacx/backlog/issues/2)
[GHHHHHTEST-3](https://github.com/Blackjacx/ghtest/issues/3)