### PR TITLE
Add `Action` Input 

### DIFF
--- a/.github/workflows/move-referenced-issue-on-pr-merge.yml
+++ b/.github/workflows/move-referenced-issue-on-pr-merge.yml
@@ -1,19 +1,19 @@
-name: Backlog Notifier
+name: Move Referenced Issue On PR Merge
 
 on:
-  push: 
-    tags:
-      - '*'
+  pull_request:
+    branches: develop
+    types: closed
 
 jobs:
-  notify-backlog:
+  move-issue:
     runs-on: ubuntu-latest
     
     steps:
     # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
     - name: Checkout
       uses: actions/checkout@v3
-    - uses: blackjacx/backlog-notifier@main
+    - uses: blackjacx/backlog-notifier@add-actions-input
       with:
         repo-references: |
           {
@@ -22,5 +22,9 @@ jobs:
               {"repo_id": "GHTEST", "repo_name": "ghtest"}
             ]
           }
+        action: move
+        project-number: 1
+        updating-field: 'Status'
+        new-field-value: 'Done'
       env:
         GITHUB_TOKEN: ${{ secrets.PERSONAL_GITHUB_TOKEN }}


### PR DESCRIPTION
# Changes

Adding a new input parameter `action` which can have the value `notify` (default) and `move`. Notify represents the old behavior and opsts comments on referenced issues. Move on the other side moves the card of an issue on a specific board (input: `board`)  to a new column (input: `new-project-board-column`)

# Issues
- https://github.com/Blackjacx/backlog-notifier/issues/25

The following is the test issue
- [GHTEST-21](https://github.com/Blackjacx/ghtest/issues/21)